### PR TITLE
Ability to book classes other than your home gym

### DIFF
--- a/api.js
+++ b/api.js
@@ -34,15 +34,16 @@ app.get('/api/table', createRxMiddleware((req$) =>
       Observable
         .fromPromise(login({ shouldSetCookies: true }).then(() => login({ email, password })))
         .flatMap(() => Observable.fromPromise(getBookableClubs()))
-        .flatMap((clubs) => {
-            var parsedClubs = JSON.parse(clubs);
-            parsedClubs.map((club) => 
-              Observable.fromPromise(getGymboxTimeTableById(club.id))  
-            )
+        .flatMap((res) => {
+            var clubs = JSON.parse(res);
+            return Observable.forkJoin(...clubs.map(
+              (club) => getGymboxTimeTableById(club.Id)
+                          .then(extractTimeTable)
+            ))
         })
-        .flatMap(extractTimeTable)
         .catch((err) => {
-          console.error('Couldnt get the time table')
+          console.log(err);
+          console.error('Couldn\'t get the time table')
           // throw new Error(err);
         })
     )

--- a/api.js
+++ b/api.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const { Observable } = require('rxjs');
 const { pick } = require('ramda');
-const { login, getGymboxTimeTable } = require('./dist/requests');
+const { login, getGymboxTimeTable, getGymboxTimeTableById, getGymboxTimeTables, getBookableClubs } = require('./dist/requests');
 const { extractTimeTable } = require('./dist/timetable');
 const { createRxMiddleware } = require('./dist/utils/rx-middleware');
 const { readfile, writeFile } = require('./dist/utils/rx-fs');
@@ -33,7 +33,13 @@ app.get('/api/table', createRxMiddleware((req$) =>
     .flatMap(() =>
       Observable
         .fromPromise(login({ shouldSetCookies: true }).then(() => login({ email, password })))
-        .flatMap(() => Observable.fromPromise(getGymboxTimeTable()))
+        .flatMap(() => Observable.fromPromise(getBookableClubs()))
+        .flatMap((clubs) => {
+            var parsedClubs = JSON.parse(clubs);
+            parsedClubs.map((club) => 
+              Observable.fromPromise(getGymboxTimeTableById(club.id))  
+            )
+        })
         .flatMap(extractTimeTable)
         .catch((err) => {
           console.error('Couldnt get the time table')

--- a/api.js
+++ b/api.js
@@ -3,7 +3,7 @@ const app = express();
 const { Observable } = require('rxjs');
 const { pick } = require('ramda');
 const { login, getGymboxTimeTable, getGymboxTimeTableById, getGymboxTimeTables, getBookableClubs } = require('./dist/requests');
-const { extractTimeTable } = require('./dist/timetable');
+const { extractTimeTable, combineTimeTables } = require('./dist/timetable');
 const { createRxMiddleware } = require('./dist/utils/rx-middleware');
 const { readfile, writeFile } = require('./dist/utils/rx-fs');
 const config = require('./data/config.json');
@@ -41,8 +41,8 @@ app.get('/api/table', createRxMiddleware((req$) =>
                           .then(extractTimeTable)
             ))
         })
+        .flatMap(combineTimeTables)
         .catch((err) => {
-          console.log(err);
           console.error('Couldn\'t get the time table')
           // throw new Error(err);
         })

--- a/api.js
+++ b/api.js
@@ -37,8 +37,7 @@ app.get('/api/table', createRxMiddleware((req$) =>
         .flatMap((res) => {
             var clubs = JSON.parse(res);
             return Observable.forkJoin(...clubs.map(
-              (club) => getGymboxTimeTableById(club.Id)
-                          .then(extractTimeTable)
+              (club) => getGymboxTimeTableById(club.Id).then((body) => extractTimeTable(club.Name, body))
             ))
         })
         .flatMap(combineTimeTables)

--- a/api.js
+++ b/api.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const { Observable } = require('rxjs');
 const { pick } = require('ramda');
-const { login, getGymboxTimeTable, getGymboxTimeTableById, getGymboxTimeTables, getBookableClubs } = require('./dist/requests');
+const { login, getGymboxTimeTable, getGymboxTimeTableById, getGymboxTimeTables, getAllClubs } = require('./dist/requests');
 const { extractTimeTable, combineTimeTables } = require('./dist/timetable');
 const { createRxMiddleware } = require('./dist/utils/rx-middleware');
 const { readfile, writeFile } = require('./dist/utils/rx-fs');
@@ -33,7 +33,7 @@ app.get('/api/table', createRxMiddleware((req$) =>
     .flatMap(() =>
       Observable
         .fromPromise(login({ shouldSetCookies: true }).then(() => login({ email, password })))
-        .flatMap(() => Observable.fromPromise(getBookableClubs()))
+        .flatMap(() => Observable.fromPromise(getAllClubs()))
         .flatMap((res) => {
             var clubs = JSON.parse(res);
             return Observable.forkJoin(...clubs.map(

--- a/dist/booking.js
+++ b/dist/booking.js
@@ -68,8 +68,7 @@ const bookClasses = (lessons) => {
 const getGymboxTimeTables = (allClubs) => {
   var clubs = JSON.parse(allClubs);
   return Promise.all(clubs.map(
-          (club) => getGymboxTimeTableById(club.Id)
-                      .then(extractTimeTable)
+          (club) => getGymboxTimeTableById(club.Id).then((body) => extractTimeTable(club.Name, body))
          ));
 }
 

--- a/dist/booking.js
+++ b/dist/booking.js
@@ -4,7 +4,7 @@ const {
   logout,
   getGymboxTimeTable,
   getGymboxTimeTableById,
-  getBookableClubs,
+  getAllClubs,
   postBooking,
   getActiveNotices,
   completeBasket,
@@ -75,7 +75,7 @@ const getGymboxTimeTables = (allClubs) => {
 const main = (email, password) => {
   login({ shouldSetCookies: true })
     .then(() => login({ email, password }))
-    .then(getBookableClubs)
+    .then(getAllClubs)
     .then(getGymboxTimeTables)
     .then(combineTimeTables)
     .then(filterAllClassesToBook)

--- a/dist/booking.js
+++ b/dist/booking.js
@@ -37,7 +37,7 @@ const filterToBook = (classes, getClassDate) => (lessons) => {
         .find(l =>(
           l.className === classes[key].className
           && l.time === classes[key].time
-          && l.location === classes[key].clubName
+          && l.location === classes[key].location
         ))
     ))
     .filter(Boolean);

--- a/dist/requests.js
+++ b/dist/requests.js
@@ -93,25 +93,6 @@ module.exports = {
       });
     });
   },
-  getGymboxTimeTables(clubs) {
-    var id = clubs[0];
-    console.log(id);
-    return new Promise((res, rej) => {
-      request.get({
-        url: `${timeTableUrl}?clubId=${id}`,
-        headers: {
-          'Cookie': cookies
-        }
-      }, (err, _, body) => {
-        if (!err) {
-          console.log('Fetched time table');
-          return res(body);
-        }
-
-        return rej(err);
-      });
-    });
-  },
   getGymboxTimeTableById(id) {
     return new Promise((res, rej) => {
       request.get({
@@ -121,7 +102,7 @@ module.exports = {
         }
       }, (err, _, body) => {
         if (!err) {
-          console.log('Fetched time table');
+          console.log(`Fetched time table for club Id ${id}`);
           return res(body);
         }
 

--- a/dist/requests.js
+++ b/dist/requests.js
@@ -77,7 +77,7 @@ module.exports = {
       });
     });
   },
-  getBookableClubs() {
+  getAllClubs() {
     return new Promise((res, rej) => {
       request.get({
         url: getClubsUrl,

--- a/dist/requests.js
+++ b/dist/requests.js
@@ -6,6 +6,7 @@ const loginUrl = `${baseUrl}/account/login`;
 const timeTableUrl = `${baseUrl}/BookingsCentre/MemberTimetable`;
 const bookClassUrl = `${baseUrl}/BookingsCentre/AddBooking`;
 const activeNotices = `${baseUrl}/notices/activenotices`;
+const getClubsUrl = `${baseUrl}/mobile/getfacilities`;
 
 const completeBasketUrl = `${baseUrl}/Basket/Pay`;
 const confirmUrl = `${baseUrl}/basket/paymentconfirmed`;
@@ -70,6 +71,58 @@ module.exports = {
         if (!err && _.statusCode === 302) {
           console.log('Logout succeed code: ', _.statusCode);
           return res();
+        }
+
+        return rej(err);
+      });
+    });
+  },
+  getBookableClubs() {
+    return new Promise((res, rej) => {
+      request.get({
+        url: getClubsUrl,
+        headers: {
+          'Cookie': cookies
+        }
+      }, (err, _, body) => {
+        if (!err) {
+          console.log('Fetched bookable clubs');
+          return res(body);
+        }
+        return rej(err);
+      });
+    });
+  },
+  getGymboxTimeTables(clubs) {
+    var id = clubs[0];
+    console.log(id);
+    return new Promise((res, rej) => {
+      request.get({
+        url: `${timeTableUrl}?clubId=${id}`,
+        headers: {
+          'Cookie': cookies
+        }
+      }, (err, _, body) => {
+        if (!err) {
+          console.log('Fetched time table');
+          return res(body);
+        }
+
+        return rej(err);
+      });
+    });
+  },
+  getGymboxTimeTableById(id) {
+    return new Promise((res, rej) => {
+      request.get({
+        url: `${timeTableUrl}?clubId=${id}`,
+        headers: {
+          'Cookie': cookies
+        }
+      }, (err, _, body) => {
+        if (!err) {
+          console.log('Fetched time table');
+          return res(body);
         }
 
         return rej(err);

--- a/dist/timetable.js
+++ b/dist/timetable.js
@@ -15,7 +15,7 @@ const extractTimeTable = (body) => {
 
     parseString(cheerio.load(timeTable).xml(), (err, result) => {
       if(!err) {
-        console.log('Extracted time table');
+        console.log(`Extracted time table for ${clubName}`);
         return res(formatTimeTable(clubName, clubId, result));
       }
 
@@ -50,7 +50,19 @@ const formatTimeTable = (clubName, clubId, timeTable) => {
   }, {});
 };
 
+const combineTimeTables = (timeTables) => {
+  return new Promise((res, reject) => {
+    return res(timeTables.reduce(function(r, e) {
+      return Object.keys(e).forEach(function(k) {
+        if(!r[k]) r[k] = [].concat(e[k])
+        else r[k] = r[k].concat(e[k])
+      }), r
+    }, {}));
+  });
+}
+
 module.exports = {
   extractTimeTable,
+  combineTimeTables,
   dateFormat
 };

--- a/dist/timetable.js
+++ b/dist/timetable.js
@@ -3,14 +3,37 @@ const cheerio = require('cheerio');
 const parseString = require('xml2js').parseString;
 const dateFormat = "YYYY-MM-DD";
 
+const extractBookableClubs = (body) => {
+  return new Promise((res, reject) => {
+    //TODO: Fix when no dropdown is found - .test()?
+    const clubsList = /<select onchange="publicTimetableHref\(this\)"[\s\S]*?<\/select>/.exec(body)[0];
+    const $ = cheerio.load(clubsList);
+    var list = [];
+    
+    $('option').each(function (index, element) {
+        list.push($(this).val().replace('MemberTimetable?clubId=', ''));
+    });
+
+    console.log(`Extracted list of club ids: ${list}`);
+
+    res();
+  });
+};
+
 const extractTimeTable = (body) => {
   return new Promise((res, reject) => {
     const timeTable = /<table id=\'MemberTimetable\'.*<\/table>/.exec(body)[0];
 
+    //TODO: Fix when no dropdown is found - .test()?
+    const selectedClub = /<option selected=\'selected\'.*?<\/option>/g.exec(body)[0];
+
+    const clubName = cheerio.load(selectedClub).text();
+    const clubId = cheerio.load(selectedClub)('option').val().replace('MemberTimetable?clubId=', '');
+
     parseString(cheerio.load(timeTable).xml(), (err, result) => {
       if(!err) {
         console.log('Extracted time table');
-        return res(formatTimeTable(result));
+        return res(formatTimeTable(clubName, clubId, result));
       }
 
       return reject(err);
@@ -18,7 +41,7 @@ const extractTimeTable = (body) => {
   });
 };
 
-const formatTimeTable = (timeTable) => {
+const formatTimeTable = (clubName, clubId, timeTable) => {
   return timeTable.table.tr.reduce((acc, tr) => {
 
     if (tr.$ && tr.$.class === 'dayHeader') {
@@ -33,6 +56,8 @@ const formatTimeTable = (timeTable) => {
         id: parseInt(tr.td[5].span[0].a[0].$.rel.split('=')[1]),
         className: tr.td[1].span[0].a[0]._,
         time: tr.td[0].span[0]._,
+        clubName: clubName || '',
+        clubId: clubId || '',
         canBook: !(tr.td[6] === 'Full' || tr.td[6] === 'Past')
       });
     }
@@ -44,5 +69,6 @@ const formatTimeTable = (timeTable) => {
 
 module.exports = {
   extractTimeTable,
+  extractBookableClubs,
   dateFormat
 };

--- a/dist/timetable.js
+++ b/dist/timetable.js
@@ -3,20 +3,14 @@ const cheerio = require('cheerio');
 const parseString = require('xml2js').parseString;
 const dateFormat = "YYYY-MM-DD";
 
-const extractTimeTable = (body) => {
+const extractTimeTable = (clubLocation, body) => {
   return new Promise((res, reject) => {
     const timeTable = /<table id=\'MemberTimetable\'.*<\/table>/.exec(body)[0];
 
-    //TODO: Fix when no dropdown is found - .test()?
-    const selectedClub = /<option selected=\'selected\'.*?<\/option>/g.exec(body)[0];
-
-    const clubName = cheerio.load(selectedClub).text();
-    const clubId = cheerio.load(selectedClub)('option').val().replace('MemberTimetable?clubId=', '');
-
     parseString(cheerio.load(timeTable).xml(), (err, result) => {
       if(!err) {
-        console.log(`Extracted time table for ${clubName}`);
-        return res(formatTimeTable(clubName, clubId, result));
+        console.log(`Extracted time table for ${clubLocation}`);
+        return res(formatTimeTable(clubLocation, result));
       }
 
       return reject(err);
@@ -24,7 +18,7 @@ const extractTimeTable = (body) => {
   });
 };
 
-const formatTimeTable = (clubName, clubId, timeTable) => {
+const formatTimeTable = (clubLocation, timeTable) => {
   return timeTable.table.tr.reduce((acc, tr) => {
 
     if (tr.$ && tr.$.class === 'dayHeader') {
@@ -39,11 +33,12 @@ const formatTimeTable = (clubName, clubId, timeTable) => {
         id: parseInt(tr.td[5].span[0].a[0].$.rel.split('=')[1]),
         className: tr.td[1].span[0].a[0]._,
         time: tr.td[0].span[0]._,
-        clubName: clubName || '',
-        clubId: clubId || '',
-        canBook: !(tr.td[6] === 'Full' || tr.td[6] === 'Past')
+        location: clubLocation,
+        canBook: !(tr.td[7] === 'Add To Waiting List' || tr.td[7] === 'Past')
       });
     }
+
+    // Object.keys(acc).forEach(k => (!acc[k] && acc[k] !== undefined) && delete acc[k]);
 
     return acc;
 

--- a/dist/timetable.js
+++ b/dist/timetable.js
@@ -3,23 +3,6 @@ const cheerio = require('cheerio');
 const parseString = require('xml2js').parseString;
 const dateFormat = "YYYY-MM-DD";
 
-const extractBookableClubs = (body) => {
-  return new Promise((res, reject) => {
-    //TODO: Fix when no dropdown is found - .test()?
-    const clubsList = /<select onchange="publicTimetableHref\(this\)"[\s\S]*?<\/select>/.exec(body)[0];
-    const $ = cheerio.load(clubsList);
-    var list = [];
-    
-    $('option').each(function (index, element) {
-        list.push($(this).val().replace('MemberTimetable?clubId=', ''));
-    });
-
-    console.log(`Extracted list of club ids: ${list}`);
-
-    res();
-  });
-};
-
 const extractTimeTable = (body) => {
   return new Promise((res, reject) => {
     const timeTable = /<table id=\'MemberTimetable\'.*<\/table>/.exec(body)[0];
@@ -69,6 +52,5 @@ const formatTimeTable = (clubName, clubId, timeTable) => {
 
 module.exports = {
   extractTimeTable,
-  extractBookableClubs,
   dateFormat
 };

--- a/dist/timetable.js
+++ b/dist/timetable.js
@@ -37,9 +37,6 @@ const formatTimeTable = (clubLocation, timeTable) => {
         canBook: !(tr.td[7] === 'Add To Waiting List' || tr.td[7] === 'Past')
       });
     }
-
-    // Object.keys(acc).forEach(k => (!acc[k] && acc[k] !== undefined) && delete acc[k]);
-
     return acc;
 
   }, {});

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,8 @@ classes.json is:
 {
   "2017-06-21": {
     "className": "Gymnastic Conditioning",
-    "time": "12:15"
+    "time": "12:15",
+    "location": "Farringdon"
   }
 }
 ```
@@ -34,7 +35,8 @@ Format for classesByDay.json is:
 {
   "Monday": {
     "className": "Gymnastic Conditioning",
-    "time": "12:15"
+    "time": "12:15",
+    "location": "Farringdon"
   }
 }
 ```


### PR DESCRIPTION
- Updated to get the full list of clubs from an endpiont
- Club location is now part of the timetable for both api and cli, which is then used to filter classes to book.
- With my limited Javascript skills, the code is not as neat as it was, also I had to pass in the clubLocation to extractTimeTable.  Feel free to suggest any improvement!

**Limitations of current implementation:**
- The gymbox /getfacilies endpoint seems to return the full list of clubs no matter what (even when you are not logged in)  With my multigym access, I am not sure what will happen to a single gym login.
- Location is always required, even for single gym user.  Looking to have a PR to default to the home gym if location is not provided, but yet to find out how I can determine what the home gym is for a user.